### PR TITLE
Compact encoding v3

### DIFF
--- a/index.js
+++ b/index.js
@@ -204,8 +204,8 @@ class Method {
     this._rpc = rpc
     this._method = method
 
-    this._request = request || c.buffer
-    this._response = response || c.buffer
+    this._request = request || c.optionalBuffer
+    this._response = response || c.optionalBuffer
     this._requestArray = c.array(this._request)
     this._responseArray = c.array(this._response)
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "b4a": "^1.6.3",
-    "compact-encoding": "^2.11.0",
+    "compact-encoding": "^3.0.0",
     "safety-catch": "^1.0.2",
     "streamx": "^2.13.2"
   }

--- a/test.js
+++ b/test.js
@@ -30,6 +30,34 @@ test('basic request/response', async (t) => {
   }
 })
 
+test('basic default request/response encoding', async (t) => {
+  const rpc1 = new RPC(send1)
+  const rpc2 = new RPC(send2)
+
+  const expected = ['hello', null]
+  const send = [Buffer.from('world'), Buffer.alloc(0)]
+  let i = 0
+  rpc1.register(0, {
+    onrequest: (data) => {
+      t.is(Buffer.isBuffer(data) ? data.toString() : data, expected[i])
+      const res = send[i]
+      i++
+      return res
+    }
+  })
+  const ping = rpc2.register(0)
+
+  t.alike(await ping.request(Buffer.from('hello')), Buffer.from('world'))
+  t.alike(await ping.request(Buffer.alloc(0)), null)
+
+  function send1(data) {
+    rpc2.recv(data)
+  }
+  function send2(data) {
+    rpc1.recv(data)
+  }
+})
+
 test('basic request/response at ID > 0', async (t) => {
   const rpc1 = new RPC(send1)
   const rpc2 = new RPC(send2)


### PR DESCRIPTION
Required using `optionalBuffer` because the default encodings for `request` & `response` were `buffer` which decodes empty buffers as `null`. Added a test to showcase the behavior. The test passes before `compact-encoding@3.0.0` and after with the commit to change the encoding to `optionalBuffer`.